### PR TITLE
Include nested classes in JAR file

### DIFF
--- a/platform/java/Makefile
+++ b/platform/java/Makefile
@@ -98,7 +98,7 @@ $(EXAMPLE_JAVA_OBJECTS): $(EXAMPLE_JAVA_SOURCES)
 REPATHED_LIBRARY_JAVA_OBJECTS := $(subst src/,,$(LIBRARY_JAVA_SOURCES:%.java=%.class))
 $(MUPDF_JAR) : $(LIBRARY_JAVA_OBJECTS)
 	rm -f $@
-	cd ../../$(OUT) && jar cf libmupdf.jar $(REPATHED_LIBRARY_JAVA_OBJECTS)
+	cd ../../$(OUT) && jar cf libmupdf.jar com
 
 mupdf_native.h : $(LIBRARY_JAVA_OBJECTS)
 	rm -f $@


### PR DESCRIPTION
In the current configuration, nested classes, e.g. `Context$Log.class` are not included in the resulting JAR file. This is because files are explicitly included by name, and their name is derived from the existence of `.java` files, replacing the file ending with `.class`. However, inner class files like `Context$Log.class` are generated by the compiler, and don't have corresponding `.java` files.

Not sure if simply replacing with `com`, the root package name, is appropriate, but it does work for me.